### PR TITLE
Add Travis CI support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+# Ubuntu 14.04 Trusty support
+sudo: required
+dist: trusty
+# Enable C++ support
+language: cpp
+# Compiler selection
+compiler:
+  - gcc
+# Install dependencies
+before_install:
+  - sudo apt-get update -qq
+  - sudo apt-get install -qq build-essential libssl-dev libboost-all-dev libdb5.1-dev libdb5.1++-dev libminiupnpc-dev make zip automake autogen libtool
+# Build steps
+script:
+  - cd src/secp256k1/
+  - chmod +x ./autogen.sh
+  - ./autogen.sh
+  - ./configure -prefix=/usr
+  - sudo make install
+  - cd ../
+  - make -f makefile.unix


### PR DESCRIPTION
Cherry-pick @SherlockStd commit from #5 to implement Travis.

I figured the earlier we get this in the repo the better to easier discover hidden bugs and assist with testing.

This will require assistance from @IonomyGuy to arrange a Travis CI account for the project.