### PR TITLE
Fix bug for miniupnpc > 1.6

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1147,10 +1147,14 @@ void ThreadMapPort()
 #ifndef UPNPDISCOVER_SUCCESS
     /* miniupnpc 1.5 */
     devlist = upnpDiscover(2000, multicastif, minissdpdpath, 0);
-#else
+#elif MINIUPNPC_API_VERSION < 14
     /* miniupnpc 1.6 */
     int error = 0;
     devlist = upnpDiscover(2000, multicastif, minissdpdpath, 0, 0, &error);
+#else
+    /* miniupnpc 1.9.20150730 */
+    int error = 0;
+    devlist = upnpDiscover(2000, multicastif, minissdpdpath, 0, 0, 2, &error);
 #endif
 
     struct UPNPUrls urls;


### PR DESCRIPTION
Resolve the following error for user of miniupnpc > 1.6 : 

```
g++ -c -O2  -pthread -Wall -Wextra -Wno-ignored-qualifiers -Wformat -Wformat-security -Wno-unused-parameter -g -DBOOST_SPIRIT_THREADSAFE -DUSE_SECP256K1 -I/root/ION/ion/src -I/root/ION/ion/src/obj -DUSE_UPNP=0 -DENABLE_WALLET -I/root/ION/ion/src/leveldb/include -I/root/ION/ion/src/leveldb/helpers -DHAVE_BUILD_INFO -fno-stack-protector -fstack-protector-all -Wstack-protector -D_FORTIFY_SOURCE=2  -MMD -MF obj/net.d -o obj/net.o net.cpp
net.cpp: In function 'void ThreadMapPort()':
net.cpp:1153:74: error: invalid conversion from 'int*' to 'unsigned char' [-fpermissive]
     devlist = upnpDiscover(2000, multicastif, minissdpdpath, 0, 0, &error);
                                                                          ^
net.cpp:1153:74: error: too few arguments to function 'UPNPDev* upnpDiscover(int, const char*, const char*, int, int, unsigned char, int*)'
In file included from net.cpp:26:0:
/usr/include/miniupnpc/miniupnpc.h:62:1: note: declared here
 upnpDiscover(int delay, const char * multicastif,
 ^
make: *** [obj/net.o] Error 1
```