### PR TITLE
Add instructions for secp256k1 error on unix

### DIFF
--- a/doc/build-unix.txt
+++ b/doc/build-unix.txt
@@ -16,6 +16,13 @@ To Build
 cd src/
 make -f makefile.unix            # Headless ion
 
+If you get an error with secp256k1, please start by compiling secp256k1 :
+
+cd src/secp256k1/
+./autogen.sh
+./configure -prefix=/usr
+sudo make install
+
 See readme-qt.rst for instructions on building ion QT,
 the graphical ion.
 


### PR DESCRIPTION
Add instructions for secp256k1 error :

```
key.cpp:17:23: fatal error: secp256k1.h: No such file or directory
 #include <secp256k1.h>
                       ^
compilation terminated.
make: *** [obj/key.o] Error 1
```