### PR TITLE
Fix two build warnings

### DIFF
--- a/src/darksend.cpp
+++ b/src/darksend.cpp
@@ -306,7 +306,7 @@ void ProcessMessageDarksend(CNode* pfrom, std::string& strCommand, CDataStream& 
             }
 
             //if(!AcceptableInputs(mempool, state, tx)){
-            bool* pfMissingInputs;
+            bool* pfMissingInputs = NULL;
 	    if(!AcceptableInputs(mempool, tx, false, pfMissingInputs)){
                 LogPrintf("dsi -- transaction not valid! \n");
                 error = _("Transaction not valid.");
@@ -975,7 +975,7 @@ bool CDarkSendPool::IsCollateralValid(const CTransaction& txCollateral){
 
     CValidationState state;
     //if(!AcceptableInputs(mempool, state, txCollateral)){
-    bool* pfMissingInputs = false;
+    bool* pfMissingInputs = NULL;
     if(!AcceptableInputs(mempool, txCollateral, false, pfMissingInputs)){
         if(fDebug) LogPrintf ("CDarkSendPool::IsCollateralValid - didn't pass IsAcceptable\n");
         return false;
@@ -1156,7 +1156,7 @@ void CDarkSendPool::SendDarksendDenominate(std::vector<CTxIn>& vin, std::vector<
         }
 
         //if(!AcceptableInputs(mempool, state, tx)){
-	bool* pfMissingInputs;
+	bool* pfMissingInputs = NULL;
 	if(!AcceptableInputs(mempool, tx, false, pfMissingInputs)){
             LogPrintf("dsi -- transaction not valid! %s \n", tx.ToString().c_str());
             return;

--- a/src/key.cpp
+++ b/src/key.cpp
@@ -549,7 +549,7 @@ bool CKey::SignCompact(const uint256 &hash, std::vector<unsigned char>& vchSig) 
     CKey nonce;
     do {
         nonce.MakeNewKey(true);
-        if (int ret = secp256k1_ecdsa_sign_compact(instance_of_csecp256k1.ctx, hash.begin(), &vchSig[1], begin(), secp256k1_nonce_function_rfc6979, NULL, &rec))
+        if (secp256k1_ecdsa_sign_compact(instance_of_csecp256k1.ctx, hash.begin(), &vchSig[1], begin(), secp256k1_nonce_function_rfc6979, NULL, &rec))
             break;
     } while(true);
 #else
@@ -629,7 +629,7 @@ bool CPubKey::VerifyCompact(const uint256 &hash, const std::vector<unsigned char
     if (vchSig.size() != 65)
         return false;
     int recid = (vchSig[0] - 27) & 3;
-    bool fComp = IsCompressed();
+//    bool fComp = IsCompressed();
     CPubKey pubkeyRec;
 /*#ifdef USE_SECP256K1
     int pubkeylen = 65;

--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -159,7 +159,7 @@ void ProcessMessageMasternode(CNode* pfrom, std::string& strCommand, CDataStream
         tx.vin.push_back(vin);
         tx.vout.push_back(vout);
         //if(AcceptableInputs(mempool, state, tx)){
-	bool* pfMissingInputs = false;
+	bool* pfMissingInputs = NULL;
 	if(AcceptableInputs(mempool, tx, false, pfMissingInputs)){
             if(fDebug) LogPrintf("dsee - Accepted masternode entry %i %i\n", count, current);
 
@@ -603,7 +603,7 @@ void CMasterNode::Check()
         tx.vout.push_back(vout);
 
         //if(!AcceptableInputs(mempool, state, tx)){
-        bool* pfMissingInputs = false;
+        bool* pfMissingInputs = NULL;
 	if(!AcceptableInputs(mempool, tx, false, pfMissingInputs)){
             enabled = 3;
             return;


### PR DESCRIPTION
Fix the two following errors : 

```
key.cpp: In member function ‘bool CKey::SignCompact(const uint256&, std::vector<unsigned char>&) const’:
key.cpp:552:17: warning: unused variable ‘ret’ [-Wunused-variable]
         if (int ret = secp256k1_ecdsa_sign_compact(instance_of_csecp256k1.ctx, hash.begin(), &vchSig[1], begin(), secp256k1_nonce_function_rfc6979, NULL, &rec))
                 ^
```

```
key.cpp: In member function ‘bool CPubKey::VerifyCompact(const uint256&, const std::vector<unsigned char>&) const’:
key.cpp:632:10: warning: unused variable ‘fComp’ [-Wunused-variable]
     bool fComp = IsCompressed();
          ^

darksend.cpp: In member function ‘bool CDarkSendPool::IsCollateralValid(const CTransaction&)’:
darksend.cpp:978:29: warning: converting ‘false’ to pointer type ‘bool*’ [-Wconversion-null]
     bool* pfMissingInputs = false;
                             ^

darksend.cpp: In member function ‘void CDarkSendPool::SendDarksendDenominate(std::vector<CTxIn>&, std::vector<CTxOut>&, int64_t)’:
darksend.cpp:1160:58: warning: ‘pfMissingInputs’ may be used uninitialized in this function [-Wmaybe-uninitialized]
  if(!AcceptableInputs(mempool, tx, false, pfMissingInputs)){
                                                          ^

darksend.cpp: In function ‘void ProcessMessageDarksend(CNode*, std::string&, CDataStream&)’:
darksend.cpp:310:62: warning: ‘pfMissingInputs’ may be used uninitialized in this function [-Wmaybe-uninitialized]
      if(!AcceptableInputs(mempool, tx, false, pfMissingInputs)){
                                                              ^

masternode.cpp: In function ‘void ProcessMessageMasternode(CNode*, std::string&, CDataStream&)’:
masternode.cpp:162:26: warning: converting ‘false’ to pointer type ‘bool*’ [-Wconversion-null]
  bool* pfMissingInputs = false;
                          ^

masternode.cpp: In member function ‘void CMasterNode::Check()’:
masternode.cpp:606:33: warning: converting ‘false’ to pointer type ‘bool*’ [-Wconversion-null]
         bool* pfMissingInputs = false;
                                 ^
```