### PR TITLE
Don't specify a point size for "Wallet" and "Recent transactions"

### DIFF
--- a/src/qt/forms/overviewpage.ui
+++ b/src/qt/forms/overviewpage.ui
@@ -56,7 +56,6 @@
              <widget class="QLabel" name="label_5">
               <property name="font">
                <font>
-                <pointsize>11</pointsize>
                 <weight>75</weight>
                 <bold>true</bold>
                </font>
@@ -560,7 +559,6 @@
              <widget class="QLabel" name="label_4">
               <property name="font">
                <font>
-                <pointsize>11</pointsize>
                 <weight>75</weight>
                 <bold>true</bold>
                </font>


### PR DESCRIPTION
This just changes the font size of the word "Wallet"  and "Recent transactions" from 11 to whatever the system default is.