### PR TITLE
Fix duplicate shortcut usage in sign/verify message dialog.

### DIFF
--- a/src/qt/forms/signverifymessagedialog.ui
+++ b/src/qt/forms/signverifymessagedialog.ui
@@ -154,7 +154,7 @@
             <string>Sign the message to prove you own this ion address</string>
            </property>
            <property name="text">
-            <string>&amp;Sign Message</string>
+            <string>Sign &amp;Message</string>
            </property>
            <property name="icon">
             <iconset resource="../bitcoin.qrc">
@@ -307,7 +307,7 @@
             <string>Verify the message to ensure it was signed with the specified ion address</string>
            </property>
            <property name="text">
-            <string>&amp;Verify Message</string>
+            <string>Verify &amp;Message</string>
            </property>
            <property name="icon">
             <iconset resource="../bitcoin.qrc">


### PR DESCRIPTION
This fixes the duplicate shortcut usage in sign(alt+s)/verify(alt+v) message dialog.

Reference:
https://github.com/bitcoin/bitcoin/commit/ecd67a142066ba7e5e2a92d152cb8bfb156d6f69