### PR TITLE
Add issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,23 @@
+<!--- Remove sections that do not apply -->
+### Describe the issue
+
+### Is the issue reproducible?
+#### List steps to reproduce below:
+1. 
+2. 
+3. 
+
+### Expected behavior
+Tell us what should happen
+
+### Actual behavior
+Tell us what happens instead
+
+### Any information in the debug.log file related to this issue?
+
+### Screenshots (if available)
+
+### What binary version was used (official or self compiled)
+
+### Machine specs: CPU, RAM, Disk space & OS (Windows, OS X, Linux) 
+


### PR DESCRIPTION
I took this idea from Bitcoin but I think it is a great idea to add an issue template.

Issue templates are new to Github and not yet implemented in this repo: [Github issue-template](https://github.com/blog/2111-issue-and-pull-request-templates)

# Example Issue Template:
### Describe the issue
This is an example issue.

### Is the issue reproducible? Yes
#### List steps to reproduce below:

1. Open Qt wallet
2. Open Menu...
3. Press test button

### Expected behavior
This is just an example.

### Actual behavior
This is just an example.

### Any information in the debug.log file related to this issue?
Example data:
2016-08-10 05:16:25 keypool added key 135, size=135

### Screenshots (if available)
N/A

### What binary version was used (official or self compiled)
official binary version 0.12.

### Machine specs: CPU, RAM, Disk space & OS (Windows, OS X, Linux)
Linux (Ubuntu) 16.04 64 bit, 2x vCPU, 2 TB disk and 6 GB RAM.