### PR TITLE
Add git-subtree-check.sh script

### DIFF
--- a/contrib/devtools/README.md
+++ b/contrib/devtools/README.md
@@ -2,6 +2,20 @@ Contents
 ========
 This directory contains tools for developers working on this repository.
 
+git-subtree-check.sh
+====================
+
+Run this script from the root of the repository to verify that a subtree matches the contents of
+the commit it claims to have been updated to.
+
+To use, make sure that you have fetched the upstream repository branch in which the subtree is
+maintained:
+* for `src/leveldb`: https://github.com/ion-core/leveldb.git (branch bitcoin-fork)
+
+Usage: `git-subtree-check.sh DIR (COMMIT)`
+
+`COMMIT` may be omitted, in which case `HEAD` is used.
+
 update-translations.py
 ======================
 

--- a/contrib/devtools/git-subtree-check.sh
+++ b/contrib/devtools/git-subtree-check.sh
@@ -1,0 +1,74 @@
+#!/bin/sh
+
+DIR="$1"
+COMMIT="$2"
+if [ -z "$COMMIT" ]; then
+    COMMIT=HEAD
+fi
+
+# Taken from git-subtree (Copyright (C) 2009 Avery Pennarun <apenwarr@gmail.com>)
+find_latest_squash()
+{
+	dir="$1"
+	sq=
+	main=
+	sub=
+	git log --grep="^git-subtree-dir: $dir/*\$" \
+		--pretty=format:'START %H%n%s%n%n%b%nEND%n' "$COMMIT" |
+	while read a b junk; do
+		case "$a" in
+			START) sq="$b" ;;
+			git-subtree-mainline:) main="$b" ;;
+			git-subtree-split:) sub="$b" ;;
+			END)
+				if [ -n "$sub" ]; then
+					if [ -n "$main" ]; then
+						# a rejoin commit?
+						# Pretend its sub was a squash.
+						sq="$sub"
+					fi
+					echo "$sq" "$sub"
+					break
+				fi
+				sq=
+				main=
+				sub=
+				;;
+		esac
+	done
+}
+
+latest_squash="$(find_latest_squash "$DIR")"
+if [ -z "$latest_squash" ]; then
+    echo "ERROR: $DIR is not a subtree" >&2
+    exit 2
+fi
+
+set $latest_squash
+old=$1
+rev=$2
+if [ "d$(git cat-file -t $rev 2>/dev/null)" != dcommit ]; then
+    echo "ERROR: subtree commit $rev unavailable. Fetch/update the subtree repository" >&2
+    exit 2
+fi
+tree_subtree=$(git show -s --format="%T" $rev)
+echo "$DIR in $COMMIT was last updated to upstream commit $rev (tree $tree_subtree)"
+tree_actual=$(git ls-tree -d "$COMMIT" "$DIR" | head -n 1)
+if [ -z "$tree_actual" ]; then
+    echo "FAIL: subtree directory $DIR not found in $COMMIT" >&2
+    exit 1
+fi
+set $tree_actual
+tree_actual_type=$2
+tree_actual_tree=$3
+echo "$DIR in $COMMIT currently refers to $tree_actual_type $tree_actual_tree"
+if [ "d$tree_actual_type" != "dtree" ]; then
+    echo "FAIL: subtree directory $DIR is not a tree in $COMMIT" >&2
+    exit 1
+fi
+if [ "$tree_actual_tree" != "$tree_subtree" ]; then
+    git diff-tree $tree_actual_tree $tree_subtree >&2
+    echo "FAIL: subtree directory tree doesn't match subtree commit tree" >&2
+    exit 1
+fi
+echo "GOOD"


### PR DESCRIPTION
A script to verify that subtree contents matches upstream subtree.

This is following the LevelDB as subtree commit (#82).

This is the result from git-subtree-check on src/leveldb as part of the LevelDB as subtree commit:
```
$ bash ./contrib/devtools/git-subtree-check.sh src/leveldb
src/leveldb in HEAD was last updated to upstream commit 42dcc7edfc98c50038e4604fa630c626db17bf42 (tree 0519102b1dcd38143ba6a9be45323ff9e2f256fd)
src/leveldb in HEAD currently refers to tree 0519102b1dcd38143ba6a9be45323ff9e2f256fd
GOOD
```

You expect it to say 'GOOD'.