### PR TITLE
fix crash: CoinControl "space" bug

### DIFF
--- a/src/qt/coincontroltreewidget.cpp
+++ b/src/qt/coincontroltreewidget.cpp
@@ -13,7 +13,8 @@ void CoinControlTreeWidget::keyPressEvent(QKeyEvent *event)
     {
         event->ignore();
         int COLUMN_CHECKBOX = 0;
-        this->currentItem()->setCheckState(COLUMN_CHECKBOX, ((this->currentItem()->checkState(COLUMN_CHECKBOX) == Qt::Checked) ? Qt::Unchecked : Qt::Checked));
+        if(this->currentItem())
+            this->currentItem()->setCheckState(COLUMN_CHECKBOX, ((this->currentItem()->checkState(COLUMN_CHECKBOX) == Qt::Checked) ? Qt::Unchecked : Qt::Checked));
     }
     else if (event->key() == Qt::Key_Escape) // press esc -> close dialog
     {


### PR DESCRIPTION
Bug description:
1. Run Ion-Qt
2. Open CoinControl
3. Click mouse here(Don't select any input)
![](https://dl.dropboxusercontent.com/u/37902134/GitHub/ionomy%3Aion/%2385_0.png)
4. Press "space"
5. Result
![](https://dl.dropboxusercontent.com/u/37902134/GitHub/ionomy%3Aion/%2385_1.png)

Fix:
this->currentItem() returns the current item in the tree widget and NULL if no selected items.
So we don't try setCheckState for NULL.

Reference:
https://github.com/bitcoin/bitcoin/commit/0eade74c783f670cb69ab982f5a828f7ff5ee0db