### PR TITLE
Qt: Network-Traffic-Graph: make some distance between line and text

### DIFF
--- a/src/qt/trafficgraphwidget.cpp
+++ b/src/qt/trafficgraphwidget.cpp
@@ -1,3 +1,8 @@
+// Copyright (c) 2011-2013 The Bitcoin Core developers
+// Copyright (c) 2016 The Ion Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #include "trafficgraphwidget.h"
 #include "clientmodel.h"
 
@@ -72,10 +77,12 @@ void TrafficGraphWidget::paintEvent(QPaintEvent *)
     int base = floor(log10(fMax));
     float val = pow(10.0f, base);
 
-    const QString units = tr("KB/s");
+    const QString units     = tr("KB/s");
+    const float yMarginText = 2.0;
+
     // draw lines
     painter.setPen(axisCol);
-    painter.drawText(XMARGIN, YMARGIN + h - h * val / fMax, QString("%1 %2").arg(val).arg(units));
+    painter.drawText(XMARGIN, YMARGIN + h - h * val / fMax-yMarginText, QString("%1 %2").arg(val).arg(units));
     for(float y = val; y < fMax; y += val) {
         int yy = YMARGIN + h - h * y / fMax;
         painter.drawLine(XMARGIN, yy, width() - XMARGIN, yy);
@@ -85,7 +92,7 @@ void TrafficGraphWidget::paintEvent(QPaintEvent *)
         axisCol = axisCol.darker();
         val = pow(10.0f, base - 1);
         painter.setPen(axisCol);
-        painter.drawText(XMARGIN, YMARGIN + h - h * val / fMax, QString("%1 %2").arg(val).arg(units));
+        painter.drawText(XMARGIN, YMARGIN + h - h * val / fMax-yMarginText, QString("%1 %2").arg(val).arg(units));
         int count = 1;
         for(float y = val; y < fMax; y += val, count++) {
             // don't overwrite lines drawn above

--- a/src/qt/trafficgraphwidget.h
+++ b/src/qt/trafficgraphwidget.h
@@ -1,5 +1,10 @@
-#ifndef TRAFFICGRAPHWIDGET_H
-#define TRAFFICGRAPHWIDGET_H
+// Copyright (c) 2011-2013 The Bitcoin Core developers
+// Copyright (c) 2016 The Ion Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef ION_QT_TRAFFICGRAPHWIDGET_H
+#define ION_QT_TRAFFICGRAPHWIDGET_H
 
 #include <QWidget>
 #include <QQueue>
@@ -41,4 +46,4 @@ private:
     ClientModel *clientModel;
 };
 
-#endif // TRAFFICGRAPHWIDGET_H
+#endif // ION_QT_TRAFFICGRAPHWIDGET_H


### PR DESCRIPTION
Text directly glued on the graph-line looks not so good.

The text currently overlaps the line:
![](https://dl.dropboxusercontent.com/u/37902134/GitHub/ionomy%3Aion/%2386_0.png)

With this PR:
![](https://dl.dropboxusercontent.com/u/37902134/GitHub/ionomy%3Aion/%2386_1.png)

Reference:
https://github.com/bitcoin/bitcoin/commit/93a3f0e7fea8699fca7e062156d7a22293d533b8